### PR TITLE
Update metric names for PuppetDB > 4

### DIFF
--- a/app/controllers/dashboard/dashboard.coffee
+++ b/app/controllers/dashboard/dashboard.coffee
@@ -1,7 +1,8 @@
 angular.module('app').controller 'DashboardCtrl', class
   constructor: (@$scope, @PuppetDB, @$location) ->
     @$scope.$on('queryChange', @loadMetrics)
-    @loadMetrics()
+    @major = @minor = @patch = null
+    @checkVersion()
 
   loadMetrics: () =>
     @getBean('num-nodes', 'activeNodes')
@@ -21,11 +22,12 @@ angular.module('app').controller 'DashboardCtrl', class
       @getNodeCount panel.query, callback(panel)
 
     @$scope.panelWidth = Math.max(2, Math.floor(12 / @$scope.panels.length))
-    @checkVersion()
 
-  getBean: (name, scopeName, multiply = 1, bean = 'puppetlabs.puppetdb.query.population') ->
+  getBean: (name, scopeName, multiply = 1) ->
     @$scope[scopeName] = undefined
-    @PuppetDB.getBean("#{bean}:type=default,name=#{name}")
+    bean = if @major > 3 then 'puppetlabs.puppetdb.population' else 'puppetlabs.puppetdb.query.population'
+    metric = if @major > 3 then "#{bean}:name=#{name}" else "#{bean}:type=default,name=#{name}"
+    @PuppetDB.getBean(metric)
       .success (data) =>
         @$scope[scopeName] = (angular.fromJson(data).Value * multiply)
           .toLocaleString()
@@ -50,10 +52,11 @@ angular.module('app').controller 'DashboardCtrl', class
 
   checkVersion: () ->
     @PuppetDB.getVersion()
-      .success (data) ->
-        major = parseInt(data.version.split('.')[0], 10)
-        minor = parseInt(data.version.split('.')[1], 10)
-        patch = parseInt(data.version.split('.')[2], 10)
-        unless major >= 3 && minor >= 2
+      .success (data) =>
+        @major = parseInt(data.version.split('.')[0], 10)
+        @minor = parseInt(data.version.split('.')[1], 10)
+        @patch = parseInt(data.version.split('.')[2], 10)
+        if @major < 4 or ( @major == 3 && @minor < 2 )
           throw new Error('This version of Puppet Explorer requires PuppetDB version 3.2.0+' +
             ", you are running PuppetDB #{data.version}")
+        @loadMetrics()


### PR DESCRIPTION
This is a fix to address #49. Also fixes the warning message that would pop up saying you needed to be running at least version 3.2.0 of PuppetDB when running >= 4.0.0.